### PR TITLE
perf: skip_stats backport

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/deltalake"
 repository = "https://github.com/delta-io/delta.rs"
 
 [workspace.dependencies]
-delta_kernel = { version = "0.19.0", features = [
+delta_kernel = { version = "0.19.2", features = [
     "arrow-57",
     "default-engine-rustls",
     "internal-api",

--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -270,7 +270,7 @@ impl Snapshot {
         log_store: &dyn LogStore,
         predicate: Option<PredicateRef>,
     ) -> SendableRBStream {
-        let scan = match self.scan_builder().with_predicate(predicate).build() {
+        let scan = match self.scan_builder().with_predicate(predicate).with_skip_stats(true).build() {
             Ok(scan) => scan,
             Err(err) => return Box::pin(once(ready(Err(err)))),
         };

--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -21,7 +21,7 @@ use arrow::array::RecordBatch;
 use arrow::compute::{filter_record_batch, is_not_null};
 use arrow::datatypes::SchemaRef;
 use arrow_arith::aggregate::sum_array_checked;
-use arrow_array::{Int64Array, StructArray};
+use arrow_array::Int64Array;
 use delta_kernel::actions::{Remove, Sidecar};
 use delta_kernel::engine::arrow_conversion::TryIntoArrow as _;
 use delta_kernel::engine::arrow_data::ArrowEngineData;
@@ -552,7 +552,11 @@ pub(crate) async fn resolve_snapshot(
 
 fn read_adds_size(array: &dyn ProvidesColumnByName) -> usize {
     if let Some(size) = ex::extract_and_cast_opt::<Int64Array>(array, "size") {
-        sum_array_checked::<arrow::array::types::Int64Type, _>(size).unwrap().unwrap_or_default() as usize
+        sum_array_checked::<arrow::array::types::Int64Type, _>(size)
+            .ok()
+            .flatten()
+            .unwrap_or_default()
+            .max(0) as usize
     } else {
         0
     }

--- a/crates/core/src/kernel/snapshot/scan.rs
+++ b/crates/core/src/kernel/snapshot/scan.rs
@@ -63,6 +63,16 @@ impl ScanBuilder {
         self
     }
 
+    /// Skip reading file statistics from checkpoint parquet files.
+    ///
+    /// When enabled, the stats column is not read from checkpoint files and data skipping
+    /// is disabled. This is useful when the caller handles data skipping externally or
+    /// doesn't need file statistics.
+    pub fn with_skip_stats(mut self, skip_stats: bool) -> Self {
+        self.inner = self.inner.with_skip_stats(skip_stats);
+        self
+    }
+
     pub fn build(self) -> DeltaResult<Scan> {
         Ok(Scan::from(self.inner.build()?))
     }


### PR DESCRIPTION
## Summary

- **perf:** backport `skip_stats` behavior from delta-kernel 0.20 to skip `stats_parsed` checkpoint deserialization for wide-table snapshot speedups (with documented trade-off that limit-based file pruning becomes a no-op when stats are absent)
- **fix:** harden `read_adds_size` against overflow/invalid values by removing panic paths and clamping negative sums before `usize` cast
- **cleanup:** remove unused import(s)