### PR TITLE
perf: skip stats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://docs.rs/deltalake"
 repository = "https://github.com/delta-io/delta.rs"
 
 [workspace.dependencies]
-delta_kernel = { version = "0.19.0", features = [
+delta_kernel = { version = "0.19.2", features = [
     "arrow-57",
     "default-engine-rustls",
     "internal-api",

--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -270,7 +270,7 @@ impl Snapshot {
         log_store: &dyn LogStore,
         predicate: Option<PredicateRef>,
     ) -> SendableRBStream {
-        let scan = match self.scan_builder().with_predicate(predicate).build() {
+        let scan = match self.scan_builder().with_predicate(predicate).with_skip_stats(true).build() {
             Ok(scan) => scan,
             Err(err) => return Box::pin(once(ready(Err(err)))),
         };

--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -270,7 +270,8 @@ impl Snapshot {
         log_store: &dyn LogStore,
         predicate: Option<PredicateRef>,
     ) -> SendableRBStream {
-        let scan = match self.scan_builder().with_predicate(predicate).with_skip_stats(true).build() {
+        let skip_stats = self.config.skip_stats_in_file_listing;
+        let scan = match self.scan_builder().with_predicate(predicate).with_skip_stats(skip_stats).build() {
             Ok(scan) => scan,
             Err(err) => return Box::pin(once(ready(Err(err)))),
         };

--- a/crates/core/src/kernel/snapshot/scan.rs
+++ b/crates/core/src/kernel/snapshot/scan.rs
@@ -63,6 +63,16 @@ impl ScanBuilder {
         self
     }
 
+    /// Skip reading file statistics from checkpoint parquet files.
+    ///
+    /// When enabled, the stats column is not read from checkpoint files and data skipping
+    /// is disabled. This is useful when the caller handles data skipping externally or
+    /// doesn't need file statistics.
+    pub fn with_skip_stats(mut self, skip_stats: bool) -> Self {
+        self.inner = self.inner.with_skip_stats(skip_stats);
+        self
+    }
+
     pub fn build(self) -> DeltaResult<Scan> {
         Ok(Scan::from(self.inner.build()?))
     }

--- a/crates/core/src/table/builder.rs
+++ b/crates/core/src/table/builder.rs
@@ -60,6 +60,12 @@ pub struct DeltaTableConfig {
 
     #[delta(skip)]
     pub log_size_limiter: Option<LogSizeLimiter>,
+
+    /// HSTACK: skip stats parsing during file listing. Runtime-only (not persisted).
+    /// Default `true` for performance; set to `false` when stats-based pruning helps the query.
+    #[serde(skip_serializing, skip_deserializing)]
+    #[delta(skip)]
+    pub skip_stats_in_file_listing: bool,
 }
 
 impl Default for DeltaTableConfig {
@@ -70,6 +76,7 @@ impl Default for DeltaTableConfig {
             log_batch_size: 1024,
             io_runtime: None,
             log_size_limiter: None,
+            skip_stats_in_file_listing: true,
         }
     }
 }
@@ -80,6 +87,7 @@ impl PartialEq for DeltaTableConfig {
             && self.log_buffer_size == other.log_buffer_size
             && self.log_batch_size == other.log_batch_size
             && self.log_size_limiter == other.log_size_limiter
+            && self.skip_stats_in_file_listing == other.skip_stats_in_file_listing
     }
 }
 


### PR DESCRIPTION
Skip stats when loading Delta table, add the option to switch this behavior on/off based on table config.